### PR TITLE
Clarify/update macOS building instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ SUMOjEdit PLUGIN
 ![screenshot](https://github.com/ontologyportal/SUMOjEdit/raw/master/screenshot-tp.jpeg)
 Started with the QuickNotepad tutorial and adapting bit by bit as a syntax checker for [SUMO](www.ontologyportal.org)
 
-This depends on [SigmaKEE](https://github.com/ontologyportal/sigmakee) and also the jEdit ErrorList plugin.
+This depends on proper installation/building of [SigmaKEE](https://github.com/ontologyportal/sigmakee).
 
 Installation-*nix
 =============================
 - You are free to use OpenJDK. Latest is JDK23
 - install jEdit.  On Ubuntu this is "sudo apt-get install jedit"
 - add to your .bashrc\
-  export JEDIT_HOME=/home/myname/.jedit editing the path to conform to your installation
+  export JEDIT_HOME=/home/myname/.jedit editing "myname" to conform to your machine home
 - Install SigmaKEE as per the [README](https://github.com/ontologyportal/sigmakee/blob/master/README.md)
 - clone SUMOjEdit into your workspace directory
 - edit build.xml to conform to your paths
@@ -20,7 +20,8 @@ Installation-*nix
   to it
 - then execute "ant" from the top SUMOjEdit directory
 - You may have to start jEdit from the command line to get it to use the correct\
-  java with: java -Xmx10g -Xss1m -jar /usr/share/jedit/jedit.jar
+  java with: java -Xmx10g -Xss1m -jar /usr/share/jedit/jedit.jar\
+  Can also create a .bashrc alias for the above java command
 
 Installation-Mac
 =============================

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Installation-Mac
 =============================
 - You are free to use OpenJDK. Latest is JDK23
 - install [jEdit](http://jedit.org/index.php?page=download&platform=mac)
-  You may need to go to System->Security&Privacy->General and allow this app
+  (Choose the Mac OS X package link)\
+  After installing, you may need to go to System->Security&Privacy->Security and allow the jedit app
 - add to your \~/.zshrc\
   export JEDIT_HOME=\~/Library/jEdit
 - Install SigmaKEE as per the [README](https://github.com/ontologyportal/sigmakee/blob/master/README.md)
@@ -35,10 +36,12 @@ Installation-Mac
   directory on a mac is /Users/myname/Library/jEdit
 - make sure you don't already have a "catalog" file in your\
   /Users/myname/Library/jEdit/modes directory, or if you do, append the contents\
-  of ~/workspace/SUMOjEdit/catalog to it
+  of ~/workspace/SUMOjEdit/catalog into it
 - then execute "ant" from the top SUMOjEdit directory
 - you may have to start jEdit from the command line to get it to use the correct\
   java with: java -Xmx10g -Xss1m -jar /Applications/jEdit.app/Contents/Java/jedit.jar
+- can also create a .zshrc alias to perfrom the above java command\
+  alias jedit="java -Xmx10g -Xss1m -jar /Applications/jEdit.app/Contents/Java/jedit.jar"
 
 To build/run/debug/test on macOS using the NetBeans IDE
 =======================================================

--- a/build.xml
+++ b/build.xml
@@ -108,7 +108,6 @@
         <copy todir="${jedit.home}/jars">
             <fileset dir="lib">
                 <exclude name="jedit.jar"/>
-                <exclude name="ErrorList.jar"/>
                 <!-- # including the jedit.jar in .jedit/jars causes strange problems -->
             </fileset>
         </copy>


### PR DESCRIPTION
Use the latest ErrorList.jar from the plugin manager to compile and run SUMOjEdit. Won't have to do an extra plugin MGR installation of ErrorList now. Will be copied over to ${jedit.home}/jars during the deploy task