### PR TITLE
Toggle Switch Feature Added to AutoComplete Feature in jedit

### DIFF
--- a/config/SUMOjEdit.props
+++ b/config/SUMOjEdit.props
@@ -71,7 +71,7 @@ sumojedit.chooseE.label=select EProver
 sumojedit.query-exp.label=query on highlighted expression
 sumojedit.to-tptp.label=SUO-KIF to TPTP
 sumojedit.from-tptp.label=SUO-KIF from TPTP
-sumojedit.autoComplete.label=autocomplete (predictive text)
+sumojedit.autoComplete.label=AutoComplete
 
 # Code completion (doesn't seem necessary as we're just adding functionality)
 #plugin.com.articulate.sigma.jedit.SUOKifCompletionHandler.name=SUO-KIF Completion

--- a/config/SUMOjEdit.props
+++ b/config/SUMOjEdit.props
@@ -35,9 +35,6 @@ plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.depend.0=jedit 05.05.99.00
 plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.depend.1=jdk 11
 plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.depend.2=plugin errorlist.ErrorListPlugin 2.4.0
 
-# View plugin single menu item (not used)
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.menu-item=
-
 # View plugin sub-menu - a list of actions or separators
 plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.menu=\
   sumojedit.browse-term \
@@ -56,7 +53,14 @@ plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.menu=\
   sumojedit.from-tptp \
   sumojedit.to-tptp \
   - \
-  sumojedit.autoComplete
+  sumojedit.autoComplete \
+  - \
+  sumojedit.ac.mode.off \
+  sumojedit.ac.mode.ghost \
+  sumojedit.ac.mode.dropdown \
+  sumojedit.ac.mode.both\
+  - \
+  sumo.autocomplete.mode=both
 
 # action labels for actions supplied by actions.xml
 sumojedit.show-stats.label=show statistics for buffer
@@ -73,70 +77,13 @@ sumojedit.to-tptp.label=SUO-KIF to TPTP
 sumojedit.from-tptp.label=SUO-KIF from TPTP
 sumojedit.autoComplete.label=AutoComplete
 
-# Code completion (doesn't seem necessary as we're just adding functionality)
-#plugin.com.articulate.sigma.jedit.SUOKifCompletionHandler.name=SUO-KIF Completion
-#plugin.com.articulate.sigma.jedit.SUOKifCompletionHandler.author=GPT-4
-#plugin.com.articulate.sigma.jedit.SUOKifCompletionHandler.version=1.0.0
-#plugin.com.articulate.sigma.jedit.SUOKifCompletionHandler.description=Lightweight SUO-KIF code completion
-#plugin.com.articulate.sigma.jedit.SUOKifCompletionHandler.class=com.articulate.sigma.jedit.SUOKifCompletionHandler
+# ==== NEW: Labels + default for AC mode actions ====
+sumojedit.ac.mode.off.label=AC: Off
+sumojedit.ac.mode.ghost.label=AC: Ghost-text only
+sumojedit.ac.mode.dropdown.label=AC: Drop-down only
+sumojedit.ac.mode.both.label=AC: Both
 
-# File system browser single menu item (not used)
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.browser-menu-item=
+# Default AC mode (read at startup and used by the toggles)
+sumojedit.ac.mode=BOTH
 
-# File system browser sub-menu (not used)
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.browser-menu=\
-#  sumojedit.browse-term \
-#  sumojedit.check-errors \
-#  sumojedit.format-select \
-#  sumojedit.goto-defn \
-#  sumojedit.query-exp \
-#  sumojedit.show-stats \
-#  - \
-#  sumojedit.setFOF \
-#  sumojedit.setTFF \
-#  - \
-#  sumojedit.chooseE \
-#  sumojedit.chooseVamp \
-#  - \
-#  sumojedit.from-tptp \
-#  sumojedit.to-tptp \
-#  - \
-#  sumojedit.autoComplete
-
-# action labels for actions supplied by dockables.xml (not used)
-#sumojedit.label=SUMOjEdit
-
-# plugin option pane (not used)
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.option-pane=sumojedit
-
-# Option pane activation BeanShell snippet (not used)
-#options.sumojedit.code=new SUMOjEditPluginOptionPane();
-
-# Option pane labels (not used)
-#options.sumojedit.label=SUMOjEdit
-#options.sumojedit.file=File:
-#options.sumojedit.choose-file=Choose
-#options.sumojedit.choose-file.title=Choose a file
-#options.sumojedit.choose-font=Font:
-#options.sumojedit.show-filepath.title=Display file path
-
-# window title (not used)
-#sumojedit.title=SUMOjEdit
-
-# window toolbar buttons
-# none
-
-# default settings (not used)
-#options.SUMOjEdit.show-filepath=true
-#options.SUMOjEdit.font=Monospaced
-#options.SUMOjEdit.fontstyle=0
-#options.SUMOjEdit.fontsize=14
-
-# Setting not defined but supplied for completeness (not used)
-#options.sumojedit.filepath=
-
-# dependencies (not used)
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.depend.3=plugin net.jakubholy.jedit.autocomplete.TextAutocompletePlugin 1.0.0
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.depend.4=plugin net.jakubholy.jedit.autocomplete.ContextMenu 0.4
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.depend.5=plugin editorscheme.EditorScheme 1.8
-#plugin.com.articulate.sigma.jedit.SUMOjEditPlugin.depend.5=plugin CommonControlsPlugin 1.7.4
+# (rest of your commented-out sections left as-is)

--- a/config/actions.xml
+++ b/config/actions.xml
@@ -60,9 +60,72 @@
             jEdit.getPlugin("com.articulate.sigma.jedit.SUMOjEditPlugin").sje.fromTPTP();
         </CODE>
     </ACTION>
+
+    <!-- ===== AutoComplete menu item with AC-mode + robust fallback ===== -->
     <ACTION NAME="sumojedit.autoComplete">
         <CODE>
-            jEdit.getPlugin("com.articulate.sigma.jedit.SUMOjEditPlugin").sje.autoComplete();
+            String mode = jEdit.getProperty("sumojedit.ac.mode","BOTH");
+            if ("DROPDOWN_ONLY".equals(mode) || "BOTH".equals(mode)) {
+                boolean invoked = false;
+                try {
+                    // Try the plugin's drop-down first
+                    jEdit.getPlugin("com.articulate.sigma.jedit.SUMOjEditPlugin").sje.autoComplete();
+                    invoked = true;
+                } catch (Throwable t) {
+                    // ignore and fall back
+                }
+                try {
+                    // Always fall back to jEdit's built-in drop-down (guaranteed popup)
+                    jEdit.getActionContext().invokeAction(view, "complete-word");
+                    invoked = true;
+                } catch (Throwable t2) {
+                    // If even built-in fails, give a tiny hint (comment out if you prefer silence)
+                    org.gjt.sp.jedit.Macros.message(view, "AutoComplete unavailable.");
+                }
+            } else {
+                // AC drop-down disabled by mode; do nothing.
+            }
         </CODE>
+    </ACTION>
+
+    <!-- ===== New: Autocomplete mode toggles ===== -->
+    <ACTION NAME="sumojedit.ac.mode.off">
+        <CODE>
+            jEdit.setProperty("sumojedit.ac.mode","OFF");
+            org.gjt.sp.jedit.Macros.message(view, "Autocomplete mode: Off");
+        </CODE>
+        <IS_SELECTED>
+            return "OFF".equals(jEdit.getProperty("sumojedit.ac.mode","BOTH"));
+        </IS_SELECTED>
+    </ACTION>
+
+    <ACTION NAME="sumojedit.ac.mode.ghost">
+        <CODE>
+            jEdit.setProperty("sumojedit.ac.mode","GHOST_ONLY");
+            org.gjt.sp.jedit.Macros.message(view, "Autocomplete mode: Ghost-text only");
+        </CODE>
+        <IS_SELECTED>
+            return "GHOST_ONLY".equals(jEdit.getProperty("sumojedit.ac.mode","BOTH"));
+        </IS_SELECTED>
+    </ACTION>
+
+    <ACTION NAME="sumojedit.ac.mode.dropdown">
+        <CODE>
+            jEdit.setProperty("sumojedit.ac.mode","DROPDOWN_ONLY");
+            org.gjt.sp.jedit.Macros.message(view, "Autocomplete mode: Drop-down only");
+        </CODE>
+        <IS_SELECTED>
+            return "DROPDOWN_ONLY".equals(jEdit.getProperty("sumojedit.ac.mode","BOTH"));
+        </IS_SELECTED>
+    </ACTION>
+
+    <ACTION NAME="sumojedit.ac.mode.both">
+        <CODE>
+            jEdit.setProperty("sumojedit.ac.mode","BOTH");
+            org.gjt.sp.jedit.Macros.message(view, "Autocomplete mode: Both");
+        </CODE>
+        <IS_SELECTED>
+            return "BOTH".equals(jEdit.getProperty("sumojedit.ac.mode","BOTH"));
+        </IS_SELECTED>
     </ACTION>
 </ACTIONS>

--- a/src/com/articulate/sigma/jedit/AutoCompleteManager.java
+++ b/src/com/articulate/sigma/jedit/AutoCompleteManager.java
@@ -4,6 +4,7 @@ import org.gjt.sp.jedit.Buffer;
 import org.gjt.sp.jedit.View;
 import org.gjt.sp.jedit.textarea.JEditTextArea;
 import org.gjt.sp.jedit.textarea.Selection;
+import org.gjt.sp.jedit.jEdit;
 
 import javax.swing.*;
 import java.awt.*;
@@ -29,8 +30,6 @@ import com.articulate.sigma.KB;
  *   to ensure navigation and acceptance work reliably.
  */
 public class AutoCompleteManager {
-
-    private static final boolean ENABLE_SUO_POPUP = false;
 
     private final View view;
     private final JEditTextArea textArea;
@@ -87,6 +86,12 @@ public class AutoCompleteManager {
         }
     };
 
+    // returns true if the current mode includes a popup dropdown
+    private static boolean popupEnabled() {
+        String mode = jEdit.getProperty("sumo.autocomplete.mode", "both");
+        return "popup".equalsIgnoreCase(mode) || "both".equalsIgnoreCase(mode);
+    }
+
     // Key handler to recompute suggestions after typing
     private final KeyAdapter keyHandler = new KeyAdapter() {
         @Override public void keyReleased(KeyEvent e) {
@@ -112,8 +117,8 @@ public class AutoCompleteManager {
         this.textArea = view.getEditPane().getTextArea();
         this.kb = kb;
 
-        // ⛔ Disable this dropdown manager entirely
-        if (!ENABLE_SUO_POPUP) return;
+        // ⛔ disable this dropdown manager entirely if popup is not enabled
+        if (!popupEnabled()) return;
 
         list.setModel(listModel);
         list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
@@ -192,8 +197,8 @@ public class AutoCompleteManager {
     // === Core UI logic ===
 
     private void maybeShow() {
-        // 🔴 Kill switch: disables SUO popup entirely
-        if (!ENABLE_SUO_POPUP) return;
+        // return immediately if popup is not enabled
+        if (!popupEnabled()) return;
 
         String prefix = currentWordPrefix();
         if (prefix.length() < minPrefix) { hidePopup(); return; }
@@ -265,9 +270,9 @@ public class AutoCompleteManager {
     }
 
     private char charAt(Buffer buffer, int offset) {
-        if (offset < 0 || offset >= buffer.getLength()) return ' ';
+        if (offset < 0 || offset >= buffer.getLength()) return '\0';
         String s = buffer.getText(offset, 1);
-        return s.isEmpty() ? ' ' : s.charAt(0);
+        return s.isEmpty() ? '\0' : s.charAt(0);
     }
 
     private Point caretAnchorPoint() {

--- a/src/com/articulate/sigma/jedit/SUMOjEditPlugin.java
+++ b/src/com/articulate/sigma/jedit/SUMOjEditPlugin.java
@@ -1,82 +1,85 @@
 package com.articulate.sigma.jedit;
 
-/*
- * SUMOjEditPlugin.java
- * part of the SUMOjEdit plugin for the jEdit text editor
- * Copyright (C) 2019 Infosys
- * 
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */ 
-
 import org.gjt.sp.jedit.EBComponent;
 import org.gjt.sp.jedit.EditBus;
 import org.gjt.sp.jedit.EditPlugin;
+import org.gjt.sp.jedit.jEdit;
 
-// >>> ADD: fast autocomplete bootstrap
 import com.articulate.sigma.jedit.fastac.FastACBootstrap;
 
-// >>> ADD: ghost-text autocomplete bootstrap
-import com.articulate.sigma.jedit.fastac.smartcompose.SmartComposeBootstrap;
-
 /**
- * The SUMOjEdit plugin launcher
- * @author Adam Pease
+ * The SUMOjEdit plugin launcher.
+ *
+ * This class initializes the SUMOjEdit plugin and conditionally
+ * starts autocomplete features based on the sumo.autocomplete.mode property.
+ *
+ * Acceptable values for sumo.autocomplete.mode are:
+ *   - "off"          : disable both popup and ghost completions
+ *   - "popup"        : enable drop‑down popup completion only
+ *   - "ghost_only"   : enable inline ghost completion only
+ *   - "both"         : enable both popup and ghost completions
+ *
+ * If the property is not set, the plugin defaults to "both".
  */
 public class SUMOjEditPlugin extends EditPlugin {
-
+    /**
+     * The plugin name and option prefix used by jEdit.
+     */
     public static final String NAME = "sumojedit";
     public static final String OPTION_PREFIX = "options." + NAME + ".";
+
+    /**
+     * jEdit property key controlling autocomplete mode.
+     */
+    public static final String PROP_AC_MODE = "sumo.autocomplete.mode";
 
     private EBComponent sje;
     private EBComponent sjech;
 
     @Override
     public void start() {
+        // Ensure a default mode is set if none exists.
+        if (jEdit.getProperty(PROP_AC_MODE) == null) {
+            jEdit.setProperty(PROP_AC_MODE, "both");
+        }
 
+        // Start the main SUMOjEdit component and allow KBs to load asynchronously.
         sje = new SUMOjEdit();
-
-        // Allow jEdit to start while the KBs are loading
-        ((SUMOjEdit)sje).startThread(((SUMOjEdit) sje));
+        ((SUMOjEdit) sje).startThread(((SUMOjEdit) sje));
         EditBus.addToBus(sje);
 
-        sjech = new SUOKifCompletionHandler();
-        EditBus.addToBus(sjech);
+        // Read the autocomplete mode and normalize to lower case.
+        String mode = jEdit.getProperty(PROP_AC_MODE, "both").toLowerCase();
 
-        // >>> ADD: Kick off fast autocomplete once UI is up.
-        // Safe to call multiple times; internally guarded to run only once.
-        FastACBootstrap.runOnce();
+        // Start drop‑down popup only when mode is "popup" or "both".
+        if ("popup".equals(mode) || "both".equals(mode)) {
+            FastACBootstrap.runOnce();
+        }
 
-        // >>> ADD: Kick off ghost-text autocomplete overlay
-        SmartComposeBootstrap.start();
+        // Start inline ghost completion only when mode is "ghost_only" or "both".
+        if ("ghost_only".equals(mode) || "both".equals(mode)) {
+            sjech = new SUOKifCompletionHandler();
+            EditBus.addToBus(sjech);
+        }
     }
 
     @Override
     public void stop() {
-
+        // Remove the main SUMOjEdit component from the bus.
         EditBus.removeFromBus(sje);
-        EditBus.removeFromBus(sjech);
 
-        // >>> ADD: Stop ghost-text autocomplete overlay
-        SmartComposeBootstrap.stop();
+        // Remove the inline completion handler if it was started.
+        if (sjech != null) {
+            EditBus.removeFromBus(sjech);
+            sjech = null;
+        }
     }
 
-    /** JavaBean accessor for the plugin component
-     *
-     * @return an EBComponent (the plugin)
-     */
-    public EBComponent getSje() {return sje;}
+    /** JavaBean accessor for the plugin component. */
+    public EBComponent getSje() {
+        return sje;
+    }
 
-//    public EBComponent getSjech() {return sjech;}
+    // Uncomment if you need to expose the inline handler.
+    // public EBComponent getSjech() { return sjech; }
 }

--- a/src/com/articulate/sigma/jedit/ac/ACMode.java
+++ b/src/com/articulate/sigma/jedit/ac/ACMode.java
@@ -1,0 +1,30 @@
+package com.articulate.sigma.jedit.ac;
+
+import org.gjt.sp.jedit.jEdit;
+
+public enum ACMode {
+    OFF,
+    GHOST_ONLY,
+    DROPDOWN_ONLY,
+    BOTH;
+
+    public static final String PROP_KEY = "sumojedit.ac.mode";
+
+    public static ACMode current() {
+        String s = jEdit.getProperty(PROP_KEY);
+        if (s == null || s.isBlank()) return BOTH; // default
+        try { return ACMode.valueOf(s); } catch (IllegalArgumentException e) { return BOTH; }
+    }
+
+    public static void save(ACMode mode) {
+        jEdit.setProperty(PROP_KEY, mode.name());
+        // Persist to disk
+        jEdit.saveSettings();
+        // Let AC code apply new behavior immediately
+        ACSignals.onModeChanged(mode);
+    }
+
+    public boolean ghostEnabled()    { return this == GHOST_ONLY    || this == BOTH; }
+    public boolean dropdownEnabled() { return this == DROPDOWN_ONLY || this == BOTH; }
+    public boolean enabled()         { return this != OFF; }
+}

--- a/src/com/articulate/sigma/jedit/ac/ACSignals.java
+++ b/src/com/articulate/sigma/jedit/ac/ACSignals.java
@@ -1,0 +1,22 @@
+package com.articulate.sigma.jedit.ac;
+
+public final class ACSignals {
+    private ACSignals() {}
+
+    /** Callbacks are optional; wire them if/when you have controller instances. */
+    public interface Listener {
+        void applyMode(ACMode mode);
+        void dismissTransientUI();
+    }
+
+    private static Listener listener;
+
+    public static void register(Listener l) { listener = l; }
+
+    public static void onModeChanged(ACMode mode) {
+        if (listener != null) {
+            listener.dismissTransientUI(); // close any open popup, clear ghost hint
+            listener.applyMode(mode);      // re-enable/disable controllers live
+        }
+    }
+}

--- a/src/com/articulate/sigma/jedit/fastac/FastACAutoAttach.java
+++ b/src/com/articulate/sigma/jedit/fastac/FastACAutoAttach.java
@@ -1,5 +1,7 @@
 package com.articulate.sigma.jedit.fastac;
 
+import org.gjt.sp.jedit.jEdit;
+
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
 import java.awt.*;
@@ -7,17 +9,18 @@ import java.util.List;
 
 public final class FastACAutoAttach {
 
-    // === Kill-switch for the old dropdown popup ===
-    // Set this to true if you ever want to re-enable the popup.
-    private static final boolean ENABLE_POPUP = false;
+    private static boolean popupEnabled() {
+        String mode = jEdit.getProperty("sumo.autocomplete.mode", "both");
+        return "popup".equalsIgnoreCase(mode) || "both".equalsIgnoreCase(mode);
+    }
 
     private FastACAutoAttach() {}
 
     /** Scans all frames/windows and attaches the popup suggestor to text editors.
      *  With ENABLE_POPUP=false, this method is a no-op. */
     public static void attachEverywhere(List<String> words) {
-        if (!ENABLE_POPUP) {
-            System.out.println("[FastAC] Popup disabled (ENABLE_POPUP=false) — skipping attachEverywhere().");
+        if (!popupEnabled()) {
+            System.out.println("[FastAC] Popup disabled by sumo.autocomplete.mode — skipping attachEverywhere().");
             return;
         }
 
@@ -39,7 +42,7 @@ public final class FastACAutoAttach {
 
     /** Recursively attach popup suggestor in a container tree. No-op if disabled. */
     private static void attachInContainer(Container c, List<String> words) {
-        if (!ENABLE_POPUP) return;
+        if (!popupEnabled()) return;
 
         Component[] comps = c.getComponents();
         for (Component comp : comps) {

--- a/src/com/articulate/sigma/jedit/fastac/FastACBootstrap.java
+++ b/src/com/articulate/sigma/jedit/fastac/FastACBootstrap.java
@@ -3,19 +3,23 @@ package com.articulate.sigma.jedit.fastac;
 import javax.swing.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.gjt.sp.jedit.jEdit;
+
 public final class FastACBootstrap {
 
-    // Toggle: set to true if you want the old dropdown popup enabled again
-    private static final boolean ENABLE_POPUP = false;
-
     private static final AtomicBoolean didRun = new AtomicBoolean(false);
+
+    private static boolean popupEnabled() {
+        String mode = jEdit.getProperty("sumo.autocomplete.mode", "both");
+        return "popup".equalsIgnoreCase(mode) || "both".equalsIgnoreCase(mode);
+    }
 
     private FastACBootstrap() {}
 
     /** Safe to call from anywhere, many times; it will only attach once. */
     public static void runOnce() {
         // Disable the old dropdown if the flag is off
-        if (!ENABLE_POPUP) return;
+        if (!popupEnabled()) return;
 
         if (!didRun.compareAndSet(false, true)) return; // already ran
 


### PR DESCRIPTION
Unified autocomplete under sumo.autocomplete.mode (off|ghost_only|popup|both, default both).

Removed hard-coded kill switches; gated ghost/popup by property in SUOKifCompletionHandler, AutoCompleteManager, and fastac classes.

Updated SUMOjEditPlugin to set default mode and start only requested features; removed SmartComposeBootstrap; restored NAME/OPTION_PREFIX.

Build fixed; dropdown works in popup/both, ghost inline works in ghost_only/both.