### PR TITLE
Copyright Information in SUMOjEditPlugin.java is restored

### DIFF
--- a/src/com/articulate/sigma/jedit/SUMOjEditPlugin.java
+++ b/src/com/articulate/sigma/jedit/SUMOjEditPlugin.java
@@ -1,5 +1,25 @@
 package com.articulate.sigma.jedit;
 
+/*
+ * SUMOjEditPlugin.java
+ * part of the SUMOjEdit plugin for the jEdit text editor
+ * Copyright (C) 2019 Infosys
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */ 
+
 import org.gjt.sp.jedit.EBComponent;
 import org.gjt.sp.jedit.EditBus;
 import org.gjt.sp.jedit.EditPlugin;


### PR DESCRIPTION
Copyright Information of SUMOjEditPlugin.java (Copyright (C) 2019 Infosys) is restored, which was deleted by mistake in the previous version.