### PR TITLE
[Simon] Addressed an issue where the AC Ghost Text mode stopped working …

### DIFF
--- a/config/SUMOjEdit.props
+++ b/config/SUMOjEdit.props
@@ -84,7 +84,7 @@ sumojedit.ac.mode.dropdown.label=AC: Drop-Down Mode
 sumojedit.ac.mode.both.label=AC: Dual Mode
 
 # Default AC mode (read at startup and used by the toggles)
-sumojedit.ac.mode.OFF
+sumojedit.ac.mode=BOTH
 
 # ===== NEW: User Guide dialog strings =====
 # Title for the dialog


### PR DESCRIPTION
After the race condition/multi-threadding fix was applied to KBUtilities.java in Sigmakee repo, the AC Ghost Text mode stopped working. 

This committ fixed the issue by
1. fixing a few import statements
2. adding debug logging to check KB initialization
3. forcing AC to initilize despite erros
4. fixing the default AC settings