### PR TITLE
[Simon] Enabled Parallelism for SUO-KIF Error Checker; Concurrent Modification Exception Fixed

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Tue Sep 16 12:20:51 PDT 2025
-build.number=233
+#Wed Sep 17 09:11:16 PDT 2025
+build.number=265

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #Build Information
-#Tue, 16 Sep 2025 12:20:46 -0700
+#Wed, 17 Sep 2025 09:11:11 -0700
 
-build.date=2025-09-16 12\:20\:46
-build.number=231
+build.date=2025-09-17 09\:11\:11
+build.number=263


### PR DESCRIPTION
[] Enabled parallelism for SUO-KIF error checking and other tasks ONLY
[] Initialization is still single-threaded to avoid arity deadlocks
[] Concurrent modification exceptions fixed by using a debounced error flusher