### PR TITLE
[Simon] SUO-KIF Error Checker Directory and File Pathway Null Bugs Fixed

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Thu Sep 25 15:46:44 PDT 2025
-build.number=283
+#Tue Sep 30 15:25:27 PDT 2025
+build.number=291

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #Build Information
-#Thu, 25 Sep 2025 15:46:40 -0700
+#Tue, 30 Sep 2025 15:25:22 -0700
 
-build.date=2025-09-25 15\:46\:40
-build.number=281
+build.date=2025-09-30 15\:25\:22
+build.number=289


### PR DESCRIPTION
The compile errors in SUMOjEdit were resolved by aligning method signatures with their call sites. The method reportAllOccurrencesInBuffer(...) was expanded to take five parameters (filePath, term, msg, bufferLines, type), and all invocations were updated to include filePath. Similarly, checkErrorsBody(...) was redefined to require (contents, filePath), and every caller—including GUI, CLI, and tests—was modified to supply the second argument. For compatibility, the unit test was either updated to pass a dummy filename or supported through a one-argument shim that delegates to the two argument version. These adjustments synchronized the method interfaces across the codebase and eliminated the argument mismatch errors.