### PR TITLE
[Simon] Major bugs fix; improved the stability of TPTP Editing Feature in SUMOjEdit

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,5 +1,5 @@
 #Build Number for SUMOjEdit
-#Tue, 21 Oct 2025 16:34:25 -0700
+#Tue, 21 Oct 2025 17:02:31 -0700
 #Build Number for ANT. Do not edit!
 #Fri Oct 03 16:11:52 PDT 2025
-build.number=1065
+build.number=1066

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #Build Information
-#Tue, 21 Oct 2025 16:34:25 -0700
+#Tue, 21 Oct 2025 17:02:31 -0700
 
-build.date=2025-10-21 16\:34\:25
-build.number=1065
+build.date=2025-10-21 17\:02\:31
+build.number=1066


### PR DESCRIPTION
1. Fixed a bug that prevented TPTP (syntactic) errors from being displayed in the error list window.
2. Fixed a bug that caused the TPTP formulas following the formula with the (syntactic) error to be omitted from the editor window and excluded from the formatting operation.