### PR TITLE
[Simon] AutoComplete Unit Tests Major Update

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,5 +1,5 @@
 #Build Number for SUMOjEdit
-#Mon, 17 Nov 2025 16:26:45 -0800
+#Tue, 18 Nov 2025 13:53:50 -0800
 #Build Number for ANT. Do not edit!
 #Fri Oct 03 16:11:52 PDT 2025
-build.number=1250
+build.number=1261

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #Build Information
-#Mon, 17 Nov 2025 16:26:45 -0800
+#Tue, 18 Nov 2025 13:53:50 -0800
 
-build.date=2025-11-17 16\:26\:45
-build.number=1250
+build.date=2025-11-18 13\:53\:50
+build.number=1261

--- a/test/unit/java/com/articulate/sigma/jedit/ACModeAndSignalsTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/ACModeAndSignalsTest.java
@@ -1,0 +1,139 @@
+package com.articulate.sigma.jedit;
+
+import com.articulate.sigma.jedit.ac.ACMode;
+import com.articulate.sigma.jedit.ac.ACSignals;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for the AutoComplete mode flags and signalling helpers:
+ *
+ *  - {@link ACMode} boolean helpers (ghostEnabled, dropdownEnabled, enabled)
+ *  - {@link ACSignals} listener dispatch semantics
+ *
+ * These tests deliberately avoid calling {@link ACMode#current()} and
+ * {@link ACMode#save(ACMode)}, since those hit jEdit's property store and
+ * settings persistence. We only exercise pure logic and the listener wiring.
+ *
+ * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.ac.ACModeAndSignalsTest">Simon Deng, NPS ORISE Intern 2025</a>
+ */
+public class ACModeAndSignalsTest {
+
+    private static final class CapturingListener implements ACSignals.Listener {
+        final List<String> calls = new ArrayList<>();
+        ACMode lastMode = null;
+
+        @Override
+        public void applyMode(ACMode mode) {
+            calls.add("apply");
+            lastMode = mode;
+        }
+
+        @Override
+        public void dismissTransientUI() {
+            calls.add("dismiss");
+        }
+    }
+
+    @Before
+    public void setUp() {
+        // Ensure a clean slate before each test.
+        ACSignals.register(null);
+    }
+
+    @After
+    public void tearDown() {
+        // Do not leak listeners into other tests.
+        ACSignals.register(null);
+    }
+
+    // ---------------------------------------------------------------------
+    // ACMode flag tests
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testACModeOffFlags() {
+        ACMode m = ACMode.OFF;
+        assertFalse(m.enabled());
+        assertFalse(m.ghostEnabled());
+        assertFalse(m.dropdownEnabled());
+    }
+
+    @Test
+    public void testACModeGhostOnlyFlags() {
+        ACMode m = ACMode.GHOST_ONLY;
+        assertTrue(m.enabled());
+        assertTrue(m.ghostEnabled());
+        assertFalse(m.dropdownEnabled());
+    }
+
+    @Test
+    public void testACModeDropdownOnlyFlags() {
+        ACMode m = ACMode.DROPDOWN_ONLY;
+        assertTrue(m.enabled());
+        assertFalse(m.ghostEnabled());
+        assertTrue(m.dropdownEnabled());
+    }
+
+    @Test
+    public void testACModeBothFlags() {
+        ACMode m = ACMode.BOTH;
+        assertTrue(m.enabled());
+        assertTrue(m.ghostEnabled());
+        assertTrue(m.dropdownEnabled());
+    }
+
+    // ---------------------------------------------------------------------
+    // ACSignals dispatch tests
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testOnModeChangedWithNoListenerDoesNothing() {
+        // Should not throw even if no listener is registered.
+        ACSignals.onModeChanged(ACMode.GHOST_ONLY);
+    }
+
+    @Test
+    public void testOnModeChangedInvokesListenerInOrder() {
+        CapturingListener listener = new CapturingListener();
+        ACSignals.register(listener);
+
+        ACSignals.onModeChanged(ACMode.DROPDOWN_ONLY);
+
+        // Expect two calls: dismiss first, then apply
+        assertEquals(2, listener.calls.size());
+        assertEquals("dismiss", listener.calls.get(0));
+        assertEquals("apply", listener.calls.get(1));
+        assertEquals(ACMode.DROPDOWN_ONLY, listener.lastMode);
+    }
+
+    @Test
+    public void testRegisterReplacesPreviousListener() {
+        CapturingListener first = new CapturingListener();
+        CapturingListener second = new CapturingListener();
+
+        ACSignals.register(first);
+        ACSignals.onModeChanged(ACMode.OFF);
+
+        ACSignals.register(second);
+        ACSignals.onModeChanged(ACMode.BOTH);
+
+        // First listener should have seen only the first call.
+        assertEquals(2, first.calls.size());
+        assertEquals("dismiss", first.calls.get(0));
+        assertEquals("apply", first.calls.get(1));
+        assertEquals(ACMode.OFF, first.lastMode);
+
+        // Second listener should have seen only the second call.
+        assertEquals(2, second.calls.size());
+        assertEquals("dismiss", second.calls.get(0));
+        assertEquals("apply", second.calls.get(1));
+        assertEquals(ACMode.BOTH, second.lastMode);
+    }
+}

--- a/test/unit/java/com/articulate/sigma/jedit/TopCompletionAdapterTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/TopCompletionAdapterTest.java
@@ -1,0 +1,103 @@
+package com.articulate.sigma.jedit;
+
+import org.gjt.sp.jedit.textarea.TextArea;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for private helper methods on
+ * com.articulate.sigma.jedit.fastac.smartcompose.TopCompletionAdapter.
+ *
+ * We use reflection because the methods under test are private/package-private
+ * and we want to avoid touching GUI code directly.
+ */
+public class TopCompletionAdapterTest {
+
+    private static Object invokePrivateStatic(String methodName,
+                                              Class<?>[] paramTypes,
+                                              Object... args) throws Exception {
+        Class<?> clazz = Class.forName(
+                "com.articulate.sigma.jedit.fastac.smartcompose.TopCompletionAdapter");
+        Method m = clazz.getDeclaredMethod(methodName, paramTypes);
+        m.setAccessible(true);
+        return m.invoke(null, args);
+    }
+
+    @Test
+    public void testIsWordRecognizesIdentifierCharacters() throws Exception {
+        // Valid identifier characters: letters, digits, '_' and '-'
+        assertTrue((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, 'a'));
+        assertTrue((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, 'Z'));
+        assertTrue((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, '0'));
+        assertTrue((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, '_'));
+        assertTrue((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, '-'));
+
+        // Non-identifier characters
+        assertFalse((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, ' '));
+        assertFalse((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, '\n'));
+        assertFalse((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, '+'));
+        assertFalse((Boolean) invokePrivateStatic(
+                "isWord", new Class[]{char.class}, '$'));
+    }
+
+    @Test
+    public void testBetterPrefersShorterCandidate() throws Exception {
+        String prefix = "inst";
+
+        // Shorter candidate should be preferred
+        assertTrue((Boolean) invokePrivateStatic(
+                "better",
+                new Class[]{String.class, String.class, String.class},
+                prefix, "instance", "instanceFoo"));
+
+        // And the inverse should be false
+        assertFalse((Boolean) invokePrivateStatic(
+                "better",
+                new Class[]{String.class, String.class, String.class},
+                prefix, "instanceFoo", "instance"));
+    }
+
+    @Test
+    public void testBetterUsesLexicographicalOrderWhenSameLength() throws Exception {
+        String prefix = "foo";
+
+        // "alpha" < "beta" lexicographically, so "alpha" is the better suggestion
+        assertTrue((Boolean) invokePrivateStatic(
+                "better",
+                new Class[]{String.class, String.class, String.class},
+                prefix, "alpha", "beta"));
+
+        // Reverse order should be false
+        assertFalse((Boolean) invokePrivateStatic(
+                "better",
+                new Class[]{String.class, String.class, String.class},
+                prefix, "beta", "alpha"));
+    }
+
+    @Test
+    public void testBestFullUsesSumoVocabularyWhenAvailable() throws Exception {
+        // The first pass in bestFull() uses the SUMO vocabulary and does not
+        // touch the TextArea parameter, so we can safely pass null here as
+        // long as the prefix matches a SUMO word (e.g. "instance").
+        Class<?> clazz = Class.forName(
+                "com.articulate.sigma.jedit.fastac.smartcompose.TopCompletionAdapter");
+        Method bestFull = clazz.getDeclaredMethod(
+                "bestFull", TextArea.class, String.class);
+        bestFull.setAccessible(true);
+
+        Object result = bestFull.invoke(null, new Object[]{null, "inst"});
+
+        assertEquals("instance", result);
+    }
+}

--- a/test/unit/java/com/articulate/sigma/jedit/UnitjEditTestSuite.java
+++ b/test/unit/java/com/articulate/sigma/jedit/UnitjEditTestSuite.java
@@ -17,7 +17,9 @@ import org.junit.runners.Suite;
     FormatSuoKifAxiomsTest.class,
     SUMOjEditHelperAdditionalNLanguageConversionTest.class,
     AutoCompleteIndexTest.class,
-    KifTermIndexTest.class
+    KifTermIndexTest.class,
+    ACModeAndSignalsTest.class,
+    TopCompletionAdapterTest.class
 })
 public class UnitjEditTestSuite {
 


### PR DESCRIPTION
Today’s work completed the full set of standalone AutoComplete unit tests in SUMOjEdit. I added targeted coverage for _every pure logic component that doesn’t depend on jEdit, Swing UI, or external repositories_. First, I tested the **KifTermIndex lookup behavior** by injecting synthetic SUMO terms and _verifying case-insensitive prefix matching, ordering, limit enforcement, and correct empty-result handling_. Next, I _validated AC configuration logic_ through ACModeAndSignalsTest.java, confirming that _each AC mode’s enable/disable flags behave correctly_ and that _ACSignals reliably dispatches mode-change events in the proper order while correctly handling listener replacement_. Finally, we tested **SmartCompose’s algorithmic helpers** in TopCompletionAdapterTest.java, ensuring _accurate word-character detection, deterministic suggestion ranking_ via the **better()** method, and _correct SUMO-vocabulary lookup_ through **bestFull()**. In total, these tests now cover all the clean, deterministic AutoComplete logic that can be exercised without GUI integration, completing the standalone AC test suite.

At the current stage, all the unit tests developed only target core functionalities and logics, and are standalone--no GUI, no other repos, or external dependencies. Unit tests with external dependencies will be added in the coming days. 