### PR TITLE
[Simon] The Last Standalone Unit Tests for SUMOjEdit

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,5 +1,5 @@
 #Build Number for SUMOjEdit
-#Wed, 19 Nov 2025 12:13:21 -0800
+#Thu, 20 Nov 2025 13:08:16 -0800
 #Build Number for ANT. Do not edit!
 #Fri Oct 03 16:11:52 PDT 2025
-build.number=1283
+build.number=1287

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #Build Information
-#Wed, 19 Nov 2025 12:13:21 -0800
+#Thu, 20 Nov 2025 13:08:16 -0800
 
-build.date=2025-11-19 12\:13\:21
-build.number=1283
+build.date=2025-11-20 13\:08\:16
+build.number=1287

--- a/test/unit/java/com/articulate/sigma/jedit/ACModeAndSignalsTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/ACModeAndSignalsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
  * {@link ACMode#save(ACMode)}, since those hit jEdit's property store and
  * settings persistence. We only exercise pure logic and the listener wiring.
  *
+ * 
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.ac.ACModeAndSignalsTest">Simon Deng, NPS ORISE Intern 2025</a>
  */
 

--- a/test/unit/java/com/articulate/sigma/jedit/AutoCompleteIndexTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/AutoCompleteIndexTest.java
@@ -18,9 +18,8 @@ import static org.junit.Assert.*;
  *
  * These tests deliberately avoid touching jEdit classes, KBmanager, or
  * any external repositories so they can run as pure unit tests.
- */
-/**
  *
+ * 
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
  */
 

--- a/test/unit/java/com/articulate/sigma/jedit/FormatSuoKifAxiomsTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/FormatSuoKifAxiomsTest.java
@@ -41,9 +41,7 @@ import static org.junit.Assert.*;
  * <p>Note: methods whose behaviour overlaps with the SUO‑KIF error
  * checking tests are intentionally omitted to avoid duplicate
  * coverage.</p>
- */
-
-/**
+ *
  *
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
  */

--- a/test/unit/java/com/articulate/sigma/jedit/KifTermIndexTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/KifTermIndexTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.*;
  * synthetic terms directly into the private {@code terms} index via reflection.
  * Only the in-memory suggestion behaviour is exercised.
  *
+ * 
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.fastac.KifTermIndexTest">Simon Deng, NPS ORISE Intern 2025</a>
  */
 public class KifTermIndexTest {

--- a/test/unit/java/com/articulate/sigma/jedit/SUMOjEditHelperAdditionalNLanguageConversionTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/SUMOjEditHelperAdditionalNLanguageConversionTest.java
@@ -38,8 +38,7 @@ import static org.junit.Assert.*;
  * for display (`safeSnippetFromFile`), how temporary files are 
  * created for TPTP tools (`writeTemp`), and how the TPTP fragment 
  * used by the SUO-KIF→TPTP translator is configured (`setFOF`, `setTFF`).
- */
-/**
+ *
  *
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
  */

--- a/test/unit/java/com/articulate/sigma/jedit/SUMOjEditResidualHelpersTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/SUMOjEditResidualHelpersTest.java
@@ -1,0 +1,308 @@
+package com.articulate.sigma.jedit;
+
+import errorlist.DefaultErrorSource;
+import errorlist.ErrorSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.articulate.sigma.jedit.SUMOjEdit;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Standalone unit tests for remaining private helper methods on
+ * {@link SUMOjEdit} that do not depend on the GUI or external
+ * ATP processes.  This class covers:
+ *
+ *  - parseIntSafe(String, int)
+ *  - findTermInLine(String, String, int) and isTermChar(char)
+ *  - findFormulaInBuffer(String, String[])
+ *  - filespecFromForms(List<Formula>, String)
+ *
+ * These helpers are exercised via reflection so that the
+ * public API of {@link SUMOjEdit} remains unchanged.
+ *
+ * 
+ * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
+ */
+
+public class SUMOjEditResidualHelpersTest {
+
+    private SUMOjEdit sje;
+
+    @Before
+    public void setUp() {
+        // Initialise a fresh SUMOjEdit instance and ErrorSource,
+        // mirroring the setup used in other SUMOjEdit tests.
+        sje = new SUMOjEdit();
+        sje.errsrc = new DefaultErrorSource(sje.getClass().getName(), null);
+        ErrorSource.registerErrorSource(sje.errsrc);
+    }
+
+    @After
+    public void tearDown() {
+        // Clean up any registered ErrorSource state between runs.
+        ErrorSource.unregisterErrorSource(sje.errsrc);
+        sje.errsrc.clear();
+        sje = null;
+    }
+
+    // ---------------------------------------------------------------------
+    // parseIntSafe(String, int)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testParseIntSafeParsesValidIntegerWithWhitespace() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("parseIntSafe", String.class, int.class);
+        m.setAccessible(true);
+
+        assertEquals(42, ((Integer) m.invoke(null, "42", 1)).intValue());
+        assertEquals(7, ((Integer) m.invoke(null, "  7  ", 3)).intValue());
+    }
+
+    @Test
+    public void testParseIntSafeFallsBackOnInvalidOrNull() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("parseIntSafe", String.class, int.class);
+        m.setAccessible(true);
+
+        // Non-numeric input should return the default
+        assertEquals(5, ((Integer) m.invoke(null, "abc", 5)).intValue());
+        // Empty string should also return the default
+        assertEquals(9, ((Integer) m.invoke(null, "", 9)).intValue());
+        // Null input should be caught and return the default
+        assertEquals(4, ((Integer) m.invoke(null, (String) null, 4)).intValue());
+    }
+
+    // ---------------------------------------------------------------------
+    // findTermInLine(String, String, int) and isTermChar(char)
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testFindTermInLineMatchesWholeTermsWithBoundaries() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("findTermInLine",
+                                                     String.class, String.class, int.class);
+        m.setAccessible(true);
+
+        String line = "The Human is an Animal.";
+        int pos = ((Integer) m.invoke(sje, line, "Human", 0)).intValue();
+        // "The " is 4 characters, so "Human" should start at index 4
+        assertEquals(4, pos);
+
+        // Term at the end of the line with punctuation
+        line = "Animal Human.";
+        pos = ((Integer) m.invoke(sje, line, "Human", 0)).intValue();
+        // "Animal " is 7 characters, so "Human" should start at index 7
+        assertEquals(7, pos);
+    }
+
+    @Test
+    public void testFindTermInLineRejectsPartialTermsInsideLargerTokens() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("findTermInLine",
+                                                     String.class, String.class, int.class);
+        m.setAccessible(true);
+
+        // "Human" appears only as part of a larger token and should not match
+        assertEquals(-1, ((Integer) m.invoke(sje, "SuperHuman", "Human", 0)).intValue());
+        assertEquals(-1, ((Integer) m.invoke(sje, "Human-Animal", "Human", 0)).intValue());
+        assertEquals(-1, ((Integer) m.invoke(sje, "XHuman_", "Human", 0)).intValue());
+    }
+
+    @Test
+    public void testIsTermCharClassification() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("isTermChar", char.class);
+        m.setAccessible(true);
+
+        // Letters, digits, '-' and '_' are term characters
+        assertTrue((Boolean) m.invoke(sje, 'A'));
+        assertTrue((Boolean) m.invoke(sje, 'z'));
+        assertTrue((Boolean) m.invoke(sje, '0'));
+        assertTrue((Boolean) m.invoke(sje, '-'));
+        assertTrue((Boolean) m.invoke(sje, '_'));
+
+        // Whitespace and punctuation are not term characters
+        assertFalse((Boolean) m.invoke(sje, ' '));
+        assertFalse((Boolean) m.invoke(sje, '.'));
+        assertFalse((Boolean) m.invoke(sje, '('));
+        assertFalse((Boolean) m.invoke(sje, ')'));
+    }
+
+    // ---------------------------------------------------------------------
+    // findFormulaInBuffer(String, String[])
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testFindFormulaInBufferMatchesFirstMeaningfulLine() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("findFormulaInBuffer",
+                                                     String.class, String[].class);
+        m.setAccessible(true);
+
+        String formula =
+                "\n\n" +
+                "fof(ax1, axiom, (p & q)).\n" +
+                "   % more stuff\n";
+
+        String[] bufferLines = new String[] {
+                "random header",
+                "    fof(ax1, axiom, (p & q)).   ",
+                "trailing text"
+        };
+
+        int idx = ((Integer) m.invoke(sje, formula, bufferLines)).intValue();
+        assertEquals(1, idx);
+    }
+
+    @Test
+    public void testFindFormulaInBufferUsesShortPrefixFallback() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("findFormulaInBuffer",
+                                                     String.class, String[].class);
+        m.setAccessible(true);
+
+        // Construct a long first line so that the method will consider a
+        // shortened prefix when the full line is not found in the buffer.
+        String longFirstLine =
+                "fof(ax2, axiom, (p & q & r & s & t & u & v)).";
+        String formula = longFirstLine + "\n% comment line\n";
+
+        // Buffer contains only the first ~20 characters of the first line,
+        // not the full line, to force the short-prefix path.
+        // We don't care about the exact 20-char boundary here; we just need
+        // to ensure the full line is not present, but its prefix is.
+        String shortPrefix = longFirstLine.substring(0, 20);
+        String[] bufferLines = new String[] {
+                "noise",
+                shortPrefix + " truncated content",
+                "more noise"
+        };
+
+        int idx = ((Integer) m.invoke(sje, formula, bufferLines)).intValue();
+        assertEquals(1, idx);
+    }
+
+    @Test
+    public void testFindFormulaInBufferReturnsMinusOneForEmptyOrMissing() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("findFormulaInBuffer",
+                                                     String.class, String[].class);
+        m.setAccessible(true);
+
+        // Empty formula: no meaningful line
+        String[] bufferLines = new String[] { "line1", "line2" };
+        assertEquals(-1, ((Integer) m.invoke(sje, "", bufferLines)).intValue());
+
+        // Formula has a first line, but it does not appear anywhere in the buffer
+        String formula = "fof(ax3, axiom, (p)).\n";
+        assertEquals(-1, ((Integer) m.invoke(sje, formula, bufferLines)).intValue());
+    }
+
+    // ---------------------------------------------------------------------
+    // filespecFromForms(List<Formula>, String)
+    // ---------------------------------------------------------------------
+
+    /**
+     * Helper to create a com.articulate.sigma.Formula instance and set
+     * its sourceFile and startLine fields via reflection, without
+     * depending on the public constructors or field visibility.
+     */
+    private Object makeFormula(String sourceFile, int startLine) throws Exception {
+        Class<?> fClass = Class.forName("com.articulate.sigma.Formula");
+        Object f = fClass.getConstructor().newInstance();
+
+        Field sourceField = fClass.getDeclaredField("sourceFile");
+        sourceField.setAccessible(true);
+        sourceField.set(f, sourceFile);
+
+        Field lineField = fClass.getDeclaredField("startLine");
+        lineField.setAccessible(true);
+        lineField.setInt(f, startLine);
+
+        return f;
+    }
+
+    /**
+     * Helper to read fields from the SUMOjEdit.FileSpec inner class.
+     */
+    private Object[] readFileSpec(Object fs) throws Exception {
+        Class<?> fsClass = Class.forName("com.articulate.sigma.jedit.SUMOjEdit$FileSpec");
+
+        Field filepathField = fsClass.getDeclaredField("filepath");
+        filepathField.setAccessible(true);
+        Field lineField = fsClass.getDeclaredField("line");
+        lineField.setAccessible(true);
+
+        String path = (String) filepathField.get(fs);
+        int line = ((Integer) lineField.get(fs)).intValue();
+
+        return new Object[] { path, line };
+    }
+
+    @Test
+    public void testFilespecFromFormsPrefersCurrentFileNonCache() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("filespecFromForms",
+                                                     List.class, String.class);
+        m.setAccessible(true);
+
+        Object f1 = makeFormula("/path/other.kif", 5);
+        Object f2 = makeFormula("/dir/MyFile.kif", 10);
+        Object f3 = makeFormula("/dir/MyFile_Cache.kif", 20); // should be ignored
+
+        List forms = new ArrayList();
+        forms.add(f1);
+        forms.add(f2);
+        forms.add(f3);
+
+        Object fs = m.invoke(sje, forms, "MyFile.kif");
+        Object[] result = readFileSpec(fs);
+
+        assertEquals("/dir/MyFile.kif", result[0]);
+        assertEquals(9, ((Integer) result[1]).intValue()); // startLine - 1
+    }
+
+    @Test
+    public void testFilespecFromFormsFallsBackToFirstNonCacheWhenNoExactMatch() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("filespecFromForms",
+                                                     List.class, String.class);
+        m.setAccessible(true);
+
+        Object f1 = makeFormula("/dir/Some_Cache.kif", 3); // cache file
+        Object f2 = makeFormula("/dir/OtherFile.kif", 7);  // first non-cache
+        Object f3 = makeFormula("/dir/Another.kif", 9);
+
+        List forms = new ArrayList();
+        forms.add(f1);
+        forms.add(f2);
+        forms.add(f3);
+
+        Object fs = m.invoke(sje, forms, "Missing.kif");
+        Object[] result = readFileSpec(fs);
+
+        assertEquals("/dir/OtherFile.kif", result[0]);
+        assertEquals(6, ((Integer) result[1]).intValue()); // startLine - 1
+    }
+
+    @Test
+    public void testFilespecFromFormsReturnsEmptyWhenAllFormsAreCache() throws Exception {
+        Method m = SUMOjEdit.class.getDeclaredMethod("filespecFromForms",
+                                                     List.class, String.class);
+        m.setAccessible(true);
+
+        Object f1 = makeFormula("/dir/Term1_Cache.kif", 2);
+        Object f2 = makeFormula("/dir/Term2_Cache.kif", 4);
+
+        List forms = new ArrayList();
+        forms.add(f1);
+        forms.add(f2);
+
+        Object fs = m.invoke(sje, forms, "MyFile.kif");
+        Object[] result = readFileSpec(fs);
+
+        // With only _Cache.kif entries, the method should return the
+        // default FileSpec, whose filepath is empty and line is -1.
+        assertEquals("", result[0]);
+        assertEquals(-1, ((Integer) result[1]).intValue());
+    }
+}

--- a/test/unit/java/com/articulate/sigma/jedit/SUOKIFErrorCheckTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/SUOKIFErrorCheckTest.java
@@ -23,8 +23,7 @@ import static org.junit.Assert.*;
  * appending.  They avoid touching any of the Sigmakee classes or
  * performing end‑to‑end error checking.  Reflection is used to
  * access private methods in order to verify their behaviour.
- */
-/**
+ *
  *
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
  */

--- a/test/unit/java/com/articulate/sigma/jedit/TPTPErrorCheckTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/TPTPErrorCheckTest.java
@@ -22,8 +22,7 @@ import static org.junit.Assert.*;
  * locating formula declarations without invoking the external tptp4X
  * binary.  Reflection is used to access private methods in order to
  * verify their behaviour.
- */
-/**
+ *
  *
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
  */

--- a/test/unit/java/com/articulate/sigma/jedit/TopCompletionAdapterTest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/TopCompletionAdapterTest.java
@@ -13,8 +13,7 @@ import static org.junit.Assert.*;
  *
  * We use reflection because the methods under test are private/package-private
  * and we want to avoid touching GUI code directly.
- */
-/**
+ *
  *
  * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
  */

--- a/test/unit/java/com/articulate/sigma/jedit/UnitjEditTestSuite.java
+++ b/test/unit/java/com/articulate/sigma/jedit/UnitjEditTestSuite.java
@@ -19,7 +19,8 @@ import org.junit.runners.Suite;
     AutoCompleteIndexTest.class,
     KifTermIndexTest.class,
     ACModeAndSignalsTest.class,
-    TopCompletionAdapterTest.class
+    TopCompletionAdapterTest.class,
+    SUMOjEditResidualHelpersTest.class
 })
 public class UnitjEditTestSuite {
 


### PR DESCRIPTION
This new test class locks down the last remaining pure-logic helpers inside SUMOjEdit so everything non-GUI and non-ATP is finally covered. It validates how SUMOjEdit safely parses integers, how it detects whole-word ontology terms inside a line, how it identifies what characters count as “term” characters, and how it locates a formula inside a text buffer using either full-line matching or short-prefix fallback. It also verifies that filespecFromForms correctly chooses the right source file and line number from a list of Formula objects, ignoring _Cache.kif files and applying the proper priority rules. In short, this test suite exhaustively checks all leftover internal string- and lookup-based logic so the core behavior of SUMOjEdit is now fully unit-tested wherever GUI and external ATP processes are not involved.