### PR TITLE
[Simon] GUI-Dependent Unit Tests for AC Ghost Text Rendering & Drop Down Menu Pop-Up Added_TS10

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,5 +1,5 @@
 #Build Number for SUMOjEdit
-#Mon, 24 Nov 2025 15:01:07 -0800
+#Tue, 25 Nov 2025 09:29:50 -0800
 #Build Number for ANT. Do not edit!
 #Fri Oct 03 16:11:52 PDT 2025
-build.number=1317
+build.number=1322

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #Build Information
-#Mon, 24 Nov 2025 15:01:07 -0800
+#Tue, 25 Nov 2025 09:29:50 -0800
 
-build.date=2025-11-24 15\:01\:07
-build.number=1317
+build.date=2025-11-25 09\:29\:50
+build.number=1322

--- a/test/unit/java/com/articulate/sigma/jedit/DropDownPopupGUITest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/DropDownPopupGUITest.java
@@ -1,0 +1,314 @@
+package com.articulate.sigma.jedit;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.edt.GuiQuery;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.junit.Test;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * GUI-level tests for a minimal AutoComplete drop-down popup harness.
+ *
+ * This does NOT depend on the real jEdit TextArea or AutoCompleteManager.
+ * It wires a small panel that:
+ *
+ *  - filters a static vocabulary as the user types
+ *  - shows a JPopupMenu with a JList of suggestions
+ *  - binds Up/Down to move selection and Enter to accept
+ *
+ * The goal is to lock in the expected drop-down interaction pattern in
+ * a deterministic, self-contained way.
+ * 
+ * 
+ * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
+ */
+
+public class DropDownPopupGUITest extends AssertJSwingJUnitTestCase {
+
+    /**
+     * Minimal panel that simulates drop-down AC behaviour.
+     */
+    private static final class DropdownPanel extends JPanel {
+
+        private final JTextField editor = new JTextField(20);
+        private final JPopupMenu popup = new JPopupMenu();
+        private final JList<String> list = new JList<>();
+        private final DefaultListModel<String> model = new DefaultListModel<>();
+        private final List<String> vocab;
+
+        DropdownPanel(List<String> vocab) {
+            super(new BorderLayout());
+            this.vocab = vocab;
+
+            editor.setName("dropdownEditor");
+
+            list.setModel(model);
+            list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+            list.setVisibleRowCount(5);
+
+            popup.add(new JScrollPane(list));
+
+            add(editor, BorderLayout.NORTH);
+
+            installDocumentListener();
+            installKeyBindings();
+        }
+
+        private void installDocumentListener() {
+            editor.getDocument().addDocumentListener(new DocumentListener() {
+                @Override
+                public void insertUpdate(DocumentEvent e) {
+                    updateSuggestions();
+                }
+
+                @Override
+                public void removeUpdate(DocumentEvent e) {
+                    updateSuggestions();
+                }
+
+                @Override
+                public void changedUpdate(DocumentEvent e) {
+                    updateSuggestions();
+                }
+            });
+        }
+
+        private void installKeyBindings() {
+            // Down arrow: move selection to next item
+            editor.getInputMap(JComponent.WHEN_FOCUSED).put(
+                    KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), "selectNext");
+            editor.getActionMap().put("selectNext", new AbstractAction() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    moveSelection(1);
+                }
+            });
+
+            // Up arrow: move selection to previous item
+            editor.getInputMap(JComponent.WHEN_FOCUSED).put(
+                    KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0), "selectPrev");
+            editor.getActionMap().put("selectPrev", new AbstractAction() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    moveSelection(-1);
+                }
+            });
+
+            // Enter: accept the currently selected suggestion
+            editor.getInputMap(JComponent.WHEN_FOCUSED).put(
+                    KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), "acceptSelection");
+            editor.getActionMap().put("acceptSelection", new AbstractAction() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    acceptSelection();
+                }
+            });
+        }
+
+        private void updateSuggestions() {
+            String prefix = editor.getText();
+            if (prefix == null) {
+                prefix = "";
+            }
+            prefix = prefix.trim().toLowerCase();
+
+            model.clear();
+            if (prefix.isEmpty()) {
+                popup.setVisible(false);
+                return;
+            }
+
+            for (String v : vocab) {
+                if (v.toLowerCase().startsWith(prefix)) {
+                    model.addElement(v);
+                }
+            }
+
+            if (model.isEmpty()) {
+                popup.setVisible(false);
+            } else {
+                if (list.getSelectedIndex() < 0 && model.getSize() > 0) {
+                    list.setSelectedIndex(0);
+                }
+                if (!popup.isVisible()) {
+                    popup.show(editor, 0, editor.getHeight());
+                }
+            }
+        }
+
+        private void moveSelection(int delta) {
+            if (!popup.isVisible() || model.isEmpty()) {
+                return;
+            }
+            int idx = list.getSelectedIndex();
+            if (idx < 0) {
+                idx = 0;
+            } else {
+                idx += delta;
+            }
+            if (idx < 0) {
+                idx = 0;
+            }
+            if (idx >= model.getSize()) {
+                idx = model.getSize() - 1;
+            }
+            list.setSelectedIndex(idx);
+            list.ensureIndexIsVisible(idx);
+        }
+
+        private void acceptSelection() {
+            if (!popup.isVisible()) {
+                return;
+            }
+            int idx = list.getSelectedIndex();
+            if (idx < 0 || idx >= model.getSize()) {
+                return;
+            }
+            String value = model.getElementAt(idx);
+            editor.setText(value);
+            popup.setVisible(false);
+        }
+
+        JTextField getEditor() {
+            return editor;
+        }
+
+        JList<String> getList() {
+            return list;
+        }
+
+        JPopupMenu getPopup() {
+            return popup;
+        }
+    }
+
+    private FrameFixture window;
+    private DropdownPanel panel;
+
+    @Override
+    protected void onSetUp() {
+        JFrame frame = GuiActionRunner.execute(new GuiQuery<JFrame>() {
+            @Override
+            protected JFrame executeInEDT() {
+                panel = new DropdownPanel(
+                        Arrays.asList("Animal", "Animate", "agent", "Zebra"));
+                JFrame f = new JFrame("Dropdown AC Harness");
+                f.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+                f.getContentPane().add(panel);
+                f.pack();
+                f.setLocationRelativeTo(null);
+                return f;
+            }
+        });
+
+        window = new FrameFixture(robot(), frame);
+        window.show();
+    }
+
+    @Override
+    protected void onTearDown() {
+        if (window != null) {
+            window.cleanUp();
+            window = null;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testPopupShowsFilteredSuggestions() {
+        window.textBox("dropdownEditor").setText("an");
+
+        JPopupMenu popup = panel.getPopup();
+        JList<String> list = panel.getList();
+
+        assertTrue("Popup should be visible when there are matches", popup.isVisible());
+        // With prefix "an", only "Animal" and "Animate" match.
+        assertEquals(2, list.getModel().getSize());
+        assertEquals("Animal", list.getModel().getElementAt(0));
+        assertEquals("Animate", list.getModel().getElementAt(1));
+    }
+
+    @Test
+    public void testArrowKeyBindingsAndSelectionMovement() {
+        JTextField editor = panel.getEditor();
+
+        // Trigger suggestions.
+        window.textBox("dropdownEditor").setText("a");
+        assertTrue(panel.getPopup().isVisible());
+        assertTrue(panel.getList().getModel().getSize() > 0);
+
+        // Verify key bindings are wired.
+        Object nextKey = editor.getInputMap(JComponent.WHEN_FOCUSED).get(
+                KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0));
+        Object prevKey = editor.getInputMap(JComponent.WHEN_FOCUSED).get(
+                KeyStroke.getKeyStroke(KeyEvent.VK_UP, 0));
+        assertEquals("selectNext", nextKey);
+        assertEquals("selectPrev", prevKey);
+
+        Action nextAction = editor.getActionMap().get(nextKey);
+        Action prevAction = editor.getActionMap().get(prevKey);
+        assertNotNull(nextAction);
+        assertNotNull(prevAction);
+
+        // Start at whatever initial selection is, then move down and up.
+        JList<String> list = panel.getList();
+        int initial = list.getSelectedIndex();
+        assertTrue("Initial selection index should be valid", initial >= 0);
+
+        GuiActionRunner.execute(() -> nextAction.actionPerformed(
+                new ActionEvent(editor, ActionEvent.ACTION_PERFORMED, "selectNext")));
+        int afterNext = list.getSelectedIndex();
+        assertTrue("Selection index should move forward or clamp", afterNext >= initial);
+
+        GuiActionRunner.execute(() -> prevAction.actionPerformed(
+                new ActionEvent(editor, ActionEvent.ACTION_PERFORMED, "selectPrev")));
+        int afterPrev = list.getSelectedIndex();
+        // Should remain within bounds
+        assertTrue(afterPrev >= 0);
+        assertTrue(afterPrev < list.getModel().getSize());
+    }
+
+    @Test
+    public void testEnterAcceptsSelectedSuggestion() {
+        JTextField editor = panel.getEditor();
+
+        // Make sure we have suggestions.
+        window.textBox("dropdownEditor").setText("ani");
+        assertTrue(panel.getPopup().isVisible());
+        JList<String> list = panel.getList();
+        assertTrue(list.getModel().getSize() > 0);
+
+        // Select the second suggestion if available (must run on the EDT).
+        if (list.getModel().getSize() > 1) {
+            GuiActionRunner.execute(() -> list.setSelectedIndex(1));
+        }
+
+        Object acceptKey = editor.getInputMap(JComponent.WHEN_FOCUSED).get(
+                KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0));
+        assertEquals("acceptSelection", acceptKey);
+
+        Action acceptAction = editor.getActionMap().get(acceptKey);
+        assertNotNull(acceptAction);
+
+        GuiActionRunner.execute(() -> acceptAction.actionPerformed(
+                new ActionEvent(editor, ActionEvent.ACTION_PERFORMED, "acceptSelection")));
+
+        String text = editor.getText();
+        assertEquals(list.getSelectedValue(), text);
+        assertFalse("Popup should hide after accepting a suggestion", panel.getPopup().isVisible());
+    }
+}

--- a/test/unit/java/com/articulate/sigma/jedit/GhostTextRenderingGUITest.java
+++ b/test/unit/java/com/articulate/sigma/jedit/GhostTextRenderingGUITest.java
@@ -1,0 +1,223 @@
+package com.articulate.sigma.jedit;
+
+import org.assertj.swing.edt.GuiActionRunner;
+import org.assertj.swing.edt.GuiQuery;
+import org.assertj.swing.fixture.FrameFixture;
+import org.assertj.swing.junit.testcase.AssertJSwingJUnitTestCase;
+import org.junit.Test;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * GUI-level tests for a minimal Ghost Text rendering harness.
+ *
+ * This does NOT use the real jEdit TextArea or SUMOjEdit AC classes.
+ * Instead it wires a small Swing panel that:
+ *
+ *  - shows a "typed" prefix in a text field
+ *  - renders a ghost suggestion for the remainder of the best match
+ *  - binds Ctrl+Tab to accept the ghost suggestion
+ *
+ * The goal is to lock in the expected user-facing behaviour and key
+ * binding semantics without depending on the full plugin runtime.
+ * 
+ * 
+ * @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
+ */
+
+public class GhostTextRenderingGUITest extends AssertJSwingJUnitTestCase {
+
+    /**
+     * Minimal panel that simulates ghost text behaviour.
+     */
+    private static final class GhostTextPanel extends JPanel {
+
+        private final JTextField editor = new JTextField(20);
+        private final JLabel ghostLabel = new JLabel();
+        private final List<String> candidates;
+
+        GhostTextPanel(List<String> candidates) {
+            super(new BorderLayout());
+            this.candidates = candidates;
+
+            editor.setName("ghostEditor");
+            ghostLabel.setName("ghostOverlayLabel");
+            ghostLabel.setForeground(Color.LIGHT_GRAY);
+
+            JPanel inner = new JPanel(new BorderLayout());
+            inner.add(editor, BorderLayout.CENTER);
+            inner.add(ghostLabel, BorderLayout.EAST);
+
+            add(inner, BorderLayout.NORTH);
+
+            installDocumentListener();
+            installKeyBinding();
+        }
+
+        private void installDocumentListener() {
+            editor.getDocument().addDocumentListener(new DocumentListener() {
+                @Override
+                public void insertUpdate(DocumentEvent e) {
+                    updateGhost();
+                }
+
+                @Override
+                public void removeUpdate(DocumentEvent e) {
+                    updateGhost();
+                }
+
+                @Override
+                public void changedUpdate(DocumentEvent e) {
+                    updateGhost();
+                }
+            });
+        }
+
+        private void installKeyBinding() {
+            KeyStroke ks = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK);
+            String actionKey = "acceptGhost";
+
+            editor.getInputMap(JComponent.WHEN_FOCUSED).put(ks, actionKey);
+            editor.getActionMap().put(actionKey, new AbstractAction() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    acceptGhost();
+                }
+            });
+        }
+
+        private void updateGhost() {
+            String text = editor.getText();
+            if (text == null) {
+                text = "";
+            }
+            text = text.trim();
+            if (text.isEmpty()) {
+                ghostLabel.setText("");
+                return;
+            }
+
+            String best = null;
+            for (String cand : candidates) {
+                if (cand.toLowerCase().startsWith(text.toLowerCase()) &&
+                    !cand.equals(text)) {
+                    if (best == null || cand.length() < best.length()) {
+                        best = cand;
+                    }
+                }
+            }
+
+            if (best == null) {
+                ghostLabel.setText("");
+            } else {
+                // Show only the remaining part of the suggestion, as ghost.
+                String remainder = best.substring(text.length());
+                ghostLabel.setText(remainder);
+            }
+        }
+
+        private void acceptGhost() {
+            String remainder = ghostLabel.getText();
+            if (remainder == null || remainder.isEmpty()) {
+                return;
+            }
+            editor.setText(editor.getText() + remainder);
+            ghostLabel.setText("");
+        }
+
+        JTextField getEditor() {
+            return editor;
+        }
+
+        JLabel getGhostLabel() {
+            return ghostLabel;
+        }
+    }
+
+    private FrameFixture window;
+    private GhostTextPanel panel;
+
+    @Override
+    protected void onSetUp() {
+        JFrame frame = GuiActionRunner.execute(new GuiQuery<JFrame>() {
+            @Override
+            protected JFrame executeInEDT() {
+                panel = new GhostTextPanel(
+                        Arrays.asList("instance", "individual", "Human", "Animal"));
+                JFrame f = new JFrame("Ghost Text Harness");
+                f.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+                f.getContentPane().add(panel);
+                f.pack();
+                f.setLocationRelativeTo(null);
+                return f;
+            }
+        });
+
+        window = new FrameFixture(robot(), frame);
+        window.show();
+    }
+
+    @Override
+    protected void onTearDown() {
+        if (window != null) {
+            window.cleanUp();
+            window = null;
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Tests
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void testGhostAppearsForMatchingPrefix() {
+        window.textBox("ghostEditor").setText("inst");
+
+        JLabel ghost = panel.getGhostLabel();
+        assertEquals("ance", ghost.getText()); // "instance" remainder
+    }
+
+    @Test
+    public void testGhostClearsWhenNoMatch() {
+        window.textBox("ghostEditor").setText("xyz");
+
+        JLabel ghost = panel.getGhostLabel();
+        assertEquals("", ghost.getText());
+    }
+
+    @Test
+    public void testCtrlTabBindingAndAcceptanceAction() {
+        JTextField editor = panel.getEditor();
+        JLabel ghost = panel.getGhostLabel();
+
+        // Start with a prefix that has a suggestion.
+        window.textBox("ghostEditor").setText("inst");
+        assertEquals("ance", ghost.getText());
+
+        // Verify the InputMap actually has Ctrl+Tab bound to "acceptGhost".
+        KeyStroke ks = KeyStroke.getKeyStroke(KeyEvent.VK_TAB, InputEvent.CTRL_DOWN_MASK);
+        Object actionKey = editor.getInputMap(JComponent.WHEN_FOCUSED).get(ks);
+        assertEquals("acceptGhost", actionKey);
+
+        // Invoke the action directly to avoid platform-specific key issues.
+        Action a = editor.getActionMap().get(actionKey);
+        assertNotNull(a);
+
+        GuiActionRunner.execute(() -> a.actionPerformed(
+                new ActionEvent(editor, ActionEvent.ACTION_PERFORMED, "acceptGhost")));
+
+        // After acceptance, the editor should contain the full word and the ghost should clear.
+        assertEquals("instance", editor.getText());
+        assertEquals("", ghost.getText());
+    }
+}

--- a/test/unit/java/com/articulate/sigma/jedit/UnitjEditTestSuite.java
+++ b/test/unit/java/com/articulate/sigma/jedit/UnitjEditTestSuite.java
@@ -5,17 +5,17 @@ import org.junit.runners.Suite;
 
 
 /**
- * NOTE: The unit tests in the following Unit Test Suites are
+ * NOTE: The unit tests in the following unit test suites are
  * either standalone or GUI-dependent, depending on the specific 
  * methods/functionalities tested by each test.
  * 
  * 
- * Standalone Unit Tests target every testable internal helper, utility,
+ * Standalone unit tests target every testable internal helper, utility,
  * parser-adjacent, method, AC-related structure, index, mode/flag system, 
  * snippet builder, KIF/TPTP message normalizer, line/offset extractor, 
  * formula locator, file-spec composer, temporary file logic, error aggregator, etc.
  * 
- * Standalone Unit Tests (all in the following Test Suites, 10 Suites in total):
+ * Standalone Unit Test Suites (10 in total):
  *  SUMOjEditTest.java
  *  SUOKIFErrorCheckTest.java
  *  TPTPErrorCheckTest.java
@@ -28,16 +28,19 @@ import org.junit.runners.Suite;
  *  SUMOjEditResidualHelpersTest.java
  * 
  * 
- * GUI-Dependent Unit Tests lock in every testable visual or event-driven piece:
+ * GUI-dependent unit tests lock in every testable visual or event-driven piece:
  * view-layer helpers, UI-state managers, widget renderers, layout calculators,
  * input dispatchers, focus/hover handlers, component lifecycles, dialog/alert
  * flows, async UI update logic, cross-thread event bridges, platform quirks,
  * and anything else the frontend can throw at us. Trust but verify.
  * 
- * GUI-Dependent Unit Tests (all in the following Test Suites, 3 Suites in total):
+ * GUI-Dependent Unit Test Suites (6 in total):
  *  ACModeToggleGUITest.java
  *  ErrorListDisplayGUITest.java
  *  ErrorListUpdateGUITest.java
+ *  ErrorListNavigationGUITest.java
+ *  GhostTextRenderingGUITest.java
+ *  DropDownPopupGUITest.java
  * 
  * 
  *  @author <a href="mailto:adam.pease@nps.edu?subject=com.articulate.sigma.jedit.SUOKIFErrorCheckTest">Simon Deng, NPS ORISE Intern 2025</a>
@@ -58,7 +61,9 @@ import org.junit.runners.Suite;
     ACModeToggleGUITest.class,
     ErrorListDisplayGUITest.class,
     ErrorListUpdateGUITest.class,
-    ErrorListNavigationGUITest.class
+    ErrorListNavigationGUITest.class,
+    GhostTextRenderingGUITest.class,
+    DropDownPopupGUITest.class
 })
 public class UnitjEditTestSuite {
 


### PR DESCRIPTION
1. Added two new GUI-dependent unit test harnesses using AssertJ Swing to cover AutoComplete visual behaviors (Inline Ghost Test Suggestion when there's a matching candidate). 
2. Implemented GhostTextRenderingGUITest to verify ghost-text display, clearing, and Ctrl+Tab acceptance.
3. Implemented DropDownPopupGUITest to validate prefix filtering, popup display, arrow-key navigation, and Enter acceptance.
4. Updated UnitjEditTestSuite to include both new suites.
5. Fixed EDT violations and corrected expected list sizes for deterministic test runs.