### PR TITLE
[Simon] AutoComplete Bug Fix

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,5 +1,5 @@
 #Build Number for SUMOjEdit
-#Tue, 25 Nov 2025 09:29:50 -0800
+#Tue, 25 Nov 2025 12:00:38 -0800
 #Build Number for ANT. Do not edit!
 #Fri Oct 03 16:11:52 PDT 2025
-build.number=1322
+build.number=1324

--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 #Build Information
-#Tue, 25 Nov 2025 09:29:50 -0800
+#Tue, 25 Nov 2025 12:00:38 -0800
 
-build.date=2025-11-25 09\:29\:50
-build.number=1322
+build.date=2025-11-25 12\:00\:38
+build.number=1324

--- a/src/com/articulate/sigma/jedit/SUOKifCompletionHandler.java
+++ b/src/com/articulate/sigma/jedit/SUOKifCompletionHandler.java
@@ -189,7 +189,18 @@ public final class SUOKifCompletionHandler implements EBComponent {
         if (view == null) return false;
         org.gjt.sp.jedit.Buffer buf = view.getBuffer();
         String path = (buf != null ? buf.getPath() : null);
-        return (path != null && path.toLowerCase().endsWith(".kif"));
+        if (path == null) return false;
+
+        String lower = path.toLowerCase();
+
+        // Treat KIF and common TPTP-style files as ghost-eligible
+        return lower.endsWith(".kif")
+                || lower.endsWith(".tff")
+                || lower.endsWith(".thf")
+                || lower.endsWith(".fof")
+                || lower.endsWith(".cnf")
+                || lower.endsWith(".p")
+                || lower.endsWith(".tptp");
     }
 
     /** Recompute after typing; accept/cancel handled by bindings/dispatcher */


### PR DESCRIPTION
Fixed a bug that prevents AutoComplete inline Ghost Text from appearing when editing a TPTP file (.thf, .tff, .fof, .cnf, etc.)